### PR TITLE
Bug Fix: clicking home link shows login page for split second before home

### DIFF
--- a/src/components/shared/MyNavbar/MyNavbar.js
+++ b/src/components/shared/MyNavbar/MyNavbar.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 
 import {
   Navbar,
-  NavbarBrand,
   Nav,
   NavItem,
   NavLink,
@@ -24,7 +23,7 @@ class MyNavbar extends React.Component {
       return (
         <div className="MyNavbar">
           <Navbar color="light" light fixed="top">
-            <NavbarBrand href="/" className="brand-header"><i className="fas fa-running"></i> Workout App</NavbarBrand>
+            <NavLink tag={RRNavLink} to="/home" className="brand-header navbar-brand"><i className="fas fa-running"></i> Workout App</NavLink>
               <Nav className="ml-auto flex-row" navbar>
                 <NavItem className="mr-2">
                   <NavLink tag={RRNavLink} to="/favorites"><i className="far fa-bookmark"></i></NavLink>


### PR DESCRIPTION
Removed the NavbarBrand component and replaced it with the NavLink reactstrap component along with the necessary RRNavLink tag and route. Then added navbar-brand bootstrap class so maintain the brand styles. The login component now should not show when clicking this link at all.