### PR TITLE
Bug Fix: Scroll to top

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Workout App</title>
+    <title>QuickFit</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/pages/Favorites/Favorites.js
+++ b/src/components/pages/Favorites/Favorites.js
@@ -20,6 +20,7 @@ class Favorites extends React.Component {
 
   componentDidMount() {
     this.getFavoriteWorkouts();
+    window.scrollTo(0, 0);
   }
 
   render() {

--- a/src/components/pages/Home/Home.js
+++ b/src/components/pages/Home/Home.js
@@ -47,6 +47,7 @@ class Home extends React.Component {
     this.getLowerExercises();
     this.getCoreExercises();
     this.getPlyoExercises();
+    window.scrollTo(0, 0);
   }
 
   randomExercise = (arr) => arr[Math.floor(Math.random() * arr.length)];

--- a/src/components/pages/LiveWorkout/LiveWorkout.js
+++ b/src/components/pages/LiveWorkout/LiveWorkout.js
@@ -52,6 +52,7 @@ class LiveWorkout extends React.Component {
         this.getSingleLowerExercise(workout.lowerExercise);
         this.getSingleCoreExercise(workout.coreExercise);
         this.getSinglePlyoExercise(workout.plyoExercise);
+        window.scrollTo(0, 0);
       })
       .catch((err) => console.error('could not get specific workout: , err'));
   }

--- a/src/components/pages/Login/Login.scss
+++ b/src/components/pages/Login/Login.scss
@@ -1,8 +1,9 @@
 .Login {
-  height: 100vh;
+  max-height: 100vh;
   display: flex;
   justify-content: center;
   flex-direction: column;
+  padding-top: 15%;
   
   #login-btn {
     margin-top: 4rem;

--- a/src/components/pages/Profile/Profile.js
+++ b/src/components/pages/Profile/Profile.js
@@ -40,6 +40,7 @@ class Profile extends React.Component {
     this.getAuthedUser();
     this.getCompletedWorkouts();
     this.getFavoriteWorkouts();
+    window.scrollTo(0, 0);
   }
 
   deleteAllWorkouts = (workoutId) => {

--- a/src/components/pages/WorkoutBuilder/WorkoutBuilder.js
+++ b/src/components/pages/WorkoutBuilder/WorkoutBuilder.js
@@ -62,6 +62,7 @@ class WorkoutBuilder extends React.Component {
   componentDidMount() {
     this.setExerciseTypes();
     this.setAllExercises();
+    window.scrollTo(0, 0);
   }
 
   submitCustomWorkout = () => {

--- a/src/components/shared/MyNavbar/MyNavbar.scss
+++ b/src/components/shared/MyNavbar/MyNavbar.scss
@@ -7,4 +7,5 @@
 .brand-header {
   font-family: 'Josefin Sans';
   font-style: italic;
+  padding-left: 0;
 }


### PR DESCRIPTION
When new components render, the page position is maintained from previous page. I added a window scroll reset in several of the componentDidMount methods across multiple components. Might be a more efficient way to do this, but it works. 